### PR TITLE
Remove pre-commit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pre-commit
 aiohttp
 unasync
 loguru


### PR DESCRIPTION
`pre-commit` is not a runtime requirement.

Development requirements and helpers should be separated to keep the module setup lean.