### PR TITLE
Remove unasync from runtime requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 aiohttp
-unasync
 loguru


### PR DESCRIPTION
Based on discussion with @pquentin in https://github.com/python-trio/unasync/issues/82, `unasync` should only be useful at build time